### PR TITLE
Compare outputs from postprocessors

### DIFF
--- a/vs-code-extension/out/src/extension.js
+++ b/vs-code-extension/out/src/extension.js
@@ -658,7 +658,9 @@ function postProcess(postLocation) {
   // get the post processor executable location
   executeCommand('notifications.clearAll');
 
-  let parameters = createParameters(postLocation, false);
+  
+  let newDebugger = vscode.workspace.getConfiguration("AutodeskPostUtility").get("newDebugger");
+  let parameters = createParameters(postLocation, false, newDebugger);
 
   var _timeout = vscode.workspace.getConfiguration("AutodeskPostUtility").get("timeoutForPostProcessing");
   _timeout *= 1000; // convert to milliseconds
@@ -785,8 +787,9 @@ function postCompare(postLocation) {
     var child = require('child_process').execFile;
     // get the post processor executable location
 
-    let parameters = createParameters(postLocation, true, false);
-    let secondaryParameters = createParameters(postLocation, true, true);
+    
+    let parameters = createParameters(postLocation, true, false, false);
+    let secondaryParameters = createParameters(postLocation, true, false, true);
 
     var _timeout = vscode.workspace.getConfiguration("AutodeskPostUtility").get("timeoutForPostProcessing");
     _timeout *= 1000; // convert to milliseconds
@@ -814,7 +817,7 @@ function postCompare(postLocation) {
 }
 
 /** Creates parameters for post processing */
-function createParameters(postLocation, isPostCompare, isSecondary = false) {
+function createParameters(postLocation, isPostCompare, newDebugger, isSecondary = false) {
 
     let parameters = ['--noeditor'];
 
@@ -826,7 +829,6 @@ function createParameters(postLocation, isPostCompare, isSecondary = false) {
 
     // Set the debug mode
     if (!isPostCompare || vscode.workspace.getConfiguration("AutodeskPostUtility").get("showDebuggedCode")) {
-      let newDebugger = vscode.workspace.getConfiguration("AutodeskPostUtility").get("newDebugger");
       let debugArg = newDebugger ? "--debugreallyall" : "--debugall";
       parameters.push(debugArg);
     }

--- a/vs-code-extension/out/src/properties.js
+++ b/vs-code-extension/out/src/properties.js
@@ -52,7 +52,7 @@ try {
                 var jsonPath = getPath().jsonPath;
                 makeFolder(propertyJSONpath)
                 interrogatePost();
-                this.checkForDifferences(true, jsonPath, jsonTemp);
+                this.checkForDifferences(true, false, jsonPath, jsonTemp);
 
                 if (!fs.existsSync(jsonPath) || !equal) { // existing user json not found or default properties were modified, start from scratch
                     if (fs.existsSync(jsonTemp)) {
@@ -144,9 +144,9 @@ try {
             return element;
         }
 
-        checkForDifferences(skipInterrogate, jsonPath, jsonTemp) {
+        checkForDifferences(skipInterrogate, isSecondary, jsonPath, jsonTemp) {
             if (!skipInterrogate) {
-                interrogatePost();
+                interrogatePost(isSecondary);
             }
             if (fs.existsSync(jsonPath)) { // check for differences in JSON files
                 if (fs.existsSync(jsonTemp)) {
@@ -245,15 +245,17 @@ try {
     }
 
     /** Returns the post location */
-    function getPostExePath() {
-        if (!fs.existsSync(postLoc)) {
-            vsc.commands.executeCommand('hsm.findPostExe');
-        }
-        if (!fs.existsSync(vsc.workspace.getConfiguration("AutodeskPostUtility").get('postExecutablePath'))) {
-            vsc.commands.executeCommand('hsm.findPostExe')
-        }
+    function getPostExePath(isSecondary = false) {
+        if (!isSecondary) {
+            if (!fs.existsSync(postLoc)) {
+                vsc.commands.executeCommand('hsm.findPostExe');
+            }
+            if (!fs.existsSync(vsc.workspace.getConfiguration("AutodeskPostUtility").get('postExecutablePath'))) {
+                vsc.commands.executeCommand('hsm.findPostExe')
+            }
 
-        wait(100);
+            wait(100);
+        }
 
         postLoc = vsc.workspace.getConfiguration("AutodeskPostUtility").get('postExecutablePath');
 
@@ -265,8 +267,8 @@ try {
     }
 
     /** Interrogate the post processor to get the property information */
-    function interrogatePost() {
-        if (getPostExePath() == undefined) {
+    function interrogatePost(isSecondary = false) {
+        if (getPostExePath(isSecondary) == undefined) {
             return;
         }
         var cpsPath = getPath().cpsPath;

--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -21,6 +21,7 @@
 		"onCommand:extension.startHSMPlugin",
 		"onCommand:hsm.showDebuggedCode",
 		"onCommand:hsm.changePostExe",
+		"onCommand:hsm.changeSecondaryPostExe",
 		"onCommand:hsm.updatePostProperties",
 		"onCommand:disableLineSelection",
 		"*",
@@ -136,6 +137,11 @@
 				"category": "Autodesk HSM Post Utility"
 			},
 			{
+				"command": "hsm.changeSecondaryPostExe",
+				"title": "Change secondary post executable",
+				"category": "Autodesk HSM Post Utility"
+			},
+			{
 				"command": "hsm.setIncludePath",
 				"title": "Set include path...",
 				"category": "Autodesk HSM Post Utility"
@@ -223,6 +229,11 @@
 			{
 				"command": "hsm.postProcess",
 				"title": "Post Process",
+				"category": "Autodesk HSM Post Utility"
+			},
+			{
+				"command": "hsm.postCompare",
+				"title": "Compare post processors",
 				"category": "Autodesk HSM Post Utility"
 			},
 			{
@@ -345,6 +356,11 @@
 					"type": "string",
 					"default": "",
 					"description": "The location for the Fusion 360 post executable"
+				},
+				"AutodeskPostUtility.secondaryPostExecutablePath": {
+					"type": "string",
+					"default": "",
+					"description": "The location for the secondary Fusion 360 post executable"
 				},
 				"AutodeskPostUtility.propertyJSON": {
 					"type": "object",


### PR DESCRIPTION
Added two commands: `Autodesk HSM Post Utility: Change secondary post executable` and `Autodesk HSM Post Utility: Compare post processors`.

`Autodesk HSM Post Utility: Change secondary post executable` allows users to browse for a post.exe.
`Autodesk HSM Post Utility: Compare post processors` runs two different post processors and opens a diff. If either post.exe is not selected, then the user will be prompted to select it and run the command again.