### PR TITLE
Enhance program name handling in post processing

### DIFF
--- a/vs-code-extension/out/src/extension.js
+++ b/vs-code-extension/out/src/extension.js
@@ -865,11 +865,18 @@ function createParameters(postLocation, isPostCompare, newDebugger, isSecondary 
   
     // Get the program name from the user settings
     let programName = vscode.workspace.getConfiguration("AutodeskPostUtility").get('programName');
+    programName = programName.trim();
     // If no name has been specified, use 1001
     if (programName == '') {
         vscode.workspace.getConfiguration("AutodeskPostUtility").update('programName', '1001', true);
         programName = '1001';
         vscode.window.showInformationMessage('Program name hasn\'t been specified, using 1001 as the name');
+    }
+    if (programName.toUpperCase() == '#CNCFILENAME') {
+      programName = path.basename(cncFile, path.extname(cncFile));
+    }
+    if (programName.indexOf("'") == -1) {
+      programName = `'${programName}'`;
     }
     parameters.push("--property", "programName", programName);
   
@@ -1515,6 +1522,7 @@ function setCNCFile(selectedFile, currentCommand = "") {
     if (postOnSelection && currentCommand === "") {
       postProcess(vscode.window.activeTextEditor.document.fileName)
     }
+    
   }
 }
 

--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -440,7 +440,7 @@
 				"AutodeskPostUtility.programName": {
 					"type": "string",
 					"default": "1001",
-					"description": "Defines the name used for post processing"
+					"description": "Defines the name used for post processing. You can input a number, an alphanumeric string, or #CNCFILENAME if you want to use the selected file's name."
 				},
 				"AutodeskPostUtility.postOnCNCSelection": {
 					"type": "boolean",


### PR DESCRIPTION
- Updated program name logic to allow using the selected CNC file's name with '#CNCFILENAME'.
- Removed the need to enclose the value in single quotes when providing an alphanumeric string in extension's Settings
- Improved description in package.json for programName configuration to clarify usage.